### PR TITLE
fix(cmd): remove usage to clarify failures

### DIFF
--- a/cmd/thumper/main.go
+++ b/cmd/thumper/main.go
@@ -27,6 +27,7 @@ func main() {
 		Long:              "An artificial load generator for managing health and performance of Authzed.",
 		PersistentPreRunE: cmd.SyncFlagsCmdFunc,
 		PreRunE:           cmd.DefaultPreRunE("thumper"),
+		SilenceUsage:      true,
 	}
 
 	cobrazerolog.New().RegisterFlags(rootCmd.PersistentFlags())


### PR DESCRIPTION
This commit removes the Cobra configuration to automatically print usage
instructions whenever the program exits with a non-zero code. This is
confusing and non-standard, e.g. `ls` or `kubectl` don't print usage
when a file is missing or a kubeconfig file is missing.

Right now, whenever you have a runtime error, e.g. failure to connect to
SpiceDB, failure to authenticate, missing permissions, etc, Thumpuer
will log errors and then print usage instructions. This was really
confusing for me and made me think I was supplying the wrong arguments
or options, and somewhat buried the actual error.

For example, connectivity to SpiceDB was broken because port-forwarding
on my container is disabled and I get the following output:

```
thumper migrate ./scripts/schema.yaml --token $THUMPER_TOKEN --endpoint $THUMPER_ENDPOINT
3:58PM INF GOMEMLIMIT is updated GOMEMLIMIT=25769803776 package=github.com/KimMachineGun/automemlimit/memlimit previous=9223372036854775807
3:58PM INF loaded script name="write basic thumper schema"
3:58PM INF running migration script script="write basic thumper schema"
Error: error running migration scripts: error running script write basic thumper schema: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:50051: connect: connection refused"
Usage:
  thumper migrate migration.yaml [migration2.yaml] [migration3.yaml] [flags]

Examples:

	Run with a single script against a local SpiceDB:
		thumper migrate ./scripts/schema.yaml --token "testtesttesttest"

	Run against authzed.com:
		thumper migrate ./scripts/schema.yaml --token "tc_test_123123123" --endpoint grpc.authzed.com --insecure=false --permissions-system mypermissionssystem

	Run with environment variables:
		THUMPER_TOKEN=testtesttesttest thumper migrate ./scripts/schema.yaml

Flags:
  -h, --help   help for migrate

Global Flags:
      --ca-path string                 override root certificate path
      --endpoint string                authzed gRPC API endpoint (default "localhost:50051")
      --insecure                       connect over a plaintext connection
      --log-format string              format of logs ("auto", "console", "json") (default "auto")
      --log-level string               verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
      --no-verify-ca                   do not attempt to verify the server's certificate chain and host name
      --otel-endpoint string           OpenTelemetry collector endpoint - the endpoint can also be set by using enviroment variables
      --otel-insecure                  connect to the OpenTelemetry collector in plaintext
      --otel-provider string           OpenTelemetry provider for tracing ("none", "otlphttp", "otlpgrpc") (default "none")
      --otel-sample-ratio float        ratio of traces that are sampled (default 0.01)
      --otel-service-name string       service name for trace data (default "thumper")
      --otel-trace-propagator string   OpenTelemetry trace propagation format ("b3", "w3c", "ottrace"). Add multiple propagators separated by comma. (default "w3c")
      --permissions-system string      permissions system to query (default "thumper")
      --token string                   token used to authenticate to authzed
```

Signed-off-by: squat <lserven@gmail.com>
