### PR TITLE
Use goccy/go-yaml for config unmarshalling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b
 	github.com/ccoveille/go-safecast v1.6.1
 	github.com/go-logr/logr v1.4.3
+	github.com/goccy/go-yaml v1.18.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f
 	github.com/mroth/weightedrand v1.0.0
@@ -20,7 +21,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.75.0
 	google.golang.org/protobuf v1.36.8
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -91,4 +91,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/ccoveille/go-safecast"
 	"github.com/rs/zerolog/log"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 // Load reads a script file, replaces the templated values with the values from

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/ccoveille/go-safecast"
-	"github.com/rs/zerolog/log"
 	"github.com/goccy/go-yaml"
+	"github.com/rs/zerolog/log"
 )
 
 // Load reads a script file, replaces the templated values with the values from

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 // Script is the top-level struct that yaml script files will be deserialized into.
@@ -54,6 +54,7 @@ type CaveatContext struct {
 	Name    string
 	Context *ProtoStruct
 }
+
 
 func (p *ProtoStruct) UnmarshalYAML(value *yaml.Node) error {
 	fmt.Println("unmarshaling proto struct")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -3,8 +3,8 @@ package config
 import (
 	"fmt"
 
-	"google.golang.org/protobuf/types/known/structpb"
 	"github.com/goccy/go-yaml"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // Script is the top-level struct that yaml script files will be deserialized into.
@@ -55,16 +55,10 @@ type CaveatContext struct {
 	Context *ProtoStruct
 }
 
-
-func (p *ProtoStruct) UnmarshalYAML(value *yaml.Node) error {
-	fmt.Println("unmarshaling proto struct")
-	if value.Kind != yaml.MappingNode {
-		return fmt.Errorf("expected mapping node, got %v", value.Kind)
-	}
-
+func (p *ProtoStruct) UnmarshalYAML(b []byte) error {
 	c := make(map[string]interface{})
 
-	if err := value.Decode(c); err != nil {
+	if err := yaml.Unmarshal(b, &c); err != nil {
 		return fmt.Errorf("failed to decode struct: %w", err)
 	}
 
@@ -164,4 +158,4 @@ func convertValue(path string, v interface{}) (*structpb.Value, error) {
 	}
 }
 
-var _ yaml.Unmarshaler = (*ProtoStruct)(nil)
+var _ yaml.BytesUnmarshaler = (*ProtoStruct)(nil)

--- a/internal/thumperrunner/prepare.go
+++ b/internal/thumperrunner/prepare.go
@@ -26,7 +26,7 @@ func Prepare(inputs []*config.Script) (prepared []*ExecutableScript, err error) 
 			var step executableStep
 			step, err = prepareStep(rawStep)
 			if err != nil {
-				return
+				return prepared, err
 			}
 
 			steps = append(steps, step)
@@ -39,7 +39,7 @@ func Prepare(inputs []*config.Script) (prepared []*ExecutableScript, err error) 
 		})
 	}
 
-	return
+	return prepared, err
 }
 
 func prepareStep(step config.ScriptStep) (executableStep, error) {
@@ -318,7 +318,7 @@ func parseComponents(obj string) (objType string, objID string, relation string)
 	if len(typeAndID) > 1 {
 		objID = typeAndID[1]
 	}
-	return
+	return objType, objID, relation
 }
 
 func parseObject(obj string) (*v1.ObjectReference, error) {


### PR DESCRIPTION
Fixes #27 

## Description
Piloting this in this repo. It seems like goccy/go-yaml is more modern and better-maintained.

## Changes
* Swap out the libs
* Update the signature of the custom unmarshaller accordingly
## Testing
Review. See that tests go green.