### PR TITLE
Implement checkbulk

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -15,6 +15,8 @@ type Script struct {
 }
 
 // ScriptStep is a single step of a thumper script, for example a single call to CheckPermissions.
+// TODO: it would be good to break this down into separate types/interfaces
+// so that it's not just one ur-type - i.e. discriminated union or something
 type ScriptStep struct {
 	Op                   string
 	Resource             string
@@ -24,9 +26,20 @@ type ScriptStep struct {
 	ExpectPermissionship string `yaml:"expectPermissionship"`
 	NumExpected          uint   `yaml:"numExpected"`
 	Updates              []Update
+	Checks               []Check
 	Schema               string
 	Consistency          string
 	Context              *ProtoStruct
+}
+
+// Check is one of a set of Checks handed to CheckBulk
+type Check struct {
+	Resource             string
+	Subject              string
+	Permission           string
+	Context              *ProtoStruct
+	ExpectNoPermission   bool   `yaml:"expectNoPermission"`
+	ExpectPermissionship string `yaml:"expectPermissionship"`
 }
 
 // Update is a mutation to a single relationship in a WriteRelationships call.

--- a/scripts/example.yaml
+++ b/scripts/example.yaml
@@ -66,3 +66,18 @@ steps:
     resource: "{{ .Prefix }}resource:seconddoc"
     subject: "{{ .Prefix }}user:fred"
     relation: "reader"
+---
+name: "checkbulk"
+weight: 30
+steps:
+  - op: "CheckBulkPermissions"
+    checks:
+      - resource: "{{ .Prefix }}resource:seconddoc"
+        subject: "{{ .Prefix }}user:fred"
+        permission: "reader"
+      - resource: "{{ .Prefix }}resource:firstdoc"
+        subject: "{{ .Prefix }}user:tom"
+        permission: "reader"
+      - resource: "{{ .Prefix }}resource:firstdoc"
+        subject: "{{ .Prefix }}user:fred"
+        permission: "reader"


### PR DESCRIPTION
Fixes #3 
Fixes #26

## Description
This has been a TODO basically since this repo was open-sourced. This implements `CheckBulk` and adds it to the example script, which should allow for richer and more realistic load tests.

## Changes
Will annotate

## Testing
Review. See that lints pass. Run it locally against a testing SpiceDB instance. Tell me to write some tests.