### PR TITLE
Step interval flag

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -35,6 +35,7 @@ var (
 func RegisterRunFlags(cmd *cobra.Command) {
 	cmd.Flags().Int("qps", 1, "queries per second to generate")
 	cmd.Flags().Duration("step-timeout", 500*time.Millisecond, "maximum time a single step is allowed to run")
+	cmd.Flags().Duration("step-interval", time.Second, "time each worker waits between steps; lower it to drive more steps per worker (effective throughput is qps / step-interval)")
 	cmd.Flags().Bool("randomize-starting-step", false, "randomize the starting script step for each worker")
 	cmd.Flags().Bool("rerender", false, "re-render each script from its source file at the start of every cycle through its steps, regenerating template values such as randomObjectID for each cycle instead of once at startup")
 
@@ -63,6 +64,7 @@ var RunCmd = &cobra.Command{
 func runCmdFunc(cmd *cobra.Command, args []string) error {
 	qps := cobrautil.MustGetInt(cmd, "qps")
 	stepTimeout := cobrautil.MustGetDuration(cmd, "step-timeout")
+	stepInterval := cobrautil.MustGetDuration(cmd, "step-interval")
 	stepRandomization := cobrautil.MustGetBool(cmd, "randomize-starting-step")
 	rerender := cobrautil.MustGetBool(cmd, "rerender")
 	psName := cobrautil.MustGetString(cmd, "permissions-system")
@@ -125,7 +127,9 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 	//	Kick off the workers.
 	//	TODO(jschorr): Add automatic disconnect if we start receiving too many errors.
 	var wg sync.WaitGroup
-	timeBetween := time.Duration(1) * time.Second / time.Duration(qps)
+	// Stagger worker starts evenly across one step interval so their ticks are
+	// spread out rather than firing all at once.
+	timeBetween := stepInterval / time.Duration(qps)
 	for i := 0; i < qps; i++ {
 		wg.Add(1)
 		index := i
@@ -138,6 +142,7 @@ func runCmdFunc(cmd *cobra.Command, args []string) error {
 				Client:            client,
 				Scripts:           workerScripts[index],
 				StepTimeout:       stepTimeout,
+				StepInterval:      stepInterval,
 				StepRandomization: stepRandomization,
 			})
 		}()

--- a/internal/thumperrunner/thumper.go
+++ b/internal/thumperrunner/thumper.go
@@ -18,6 +18,7 @@ type WorkerOptions struct {
 	Client            *authzed.Client
 	Scripts           []*ExecutableScript
 	StepTimeout       time.Duration
+	StepInterval      time.Duration
 	StepRandomization bool
 }
 
@@ -46,7 +47,11 @@ func RunWorker(options WorkerOptions) {
 
 	log.Info().Int("worker", options.Index).Msg("starting worker")
 
-	ticker := time.NewTicker(1 * time.Second)
+	stepInterval := options.StepInterval
+	if stepInterval <= 0 {
+		stepInterval = 1 * time.Second
+	}
+	ticker := time.NewTicker(stepInterval)
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	for {

--- a/scripts/some-data.yaml
+++ b/scripts/some-data.yaml
@@ -1,25 +1,28 @@
 name: load some data
 weight: 1
+# randomObjectID returns one value per render, so it is used as a per-run
+# namespace and combined with the loop indices to keep the 100 orgs (and their
+# tokens) distinct within a single run while staying unique across runs.
 steps:
 {{- range $j := enumerate 100 }}
 - op: WriteRelationships
   updates:
   - op: TOUCH
-    resource: {{ $.Prefix }}organization:org_{{ $j }}
-    subject: {{ $.Prefix }}platform:plat_{{ $j }}
+    resource: {{ $.Prefix }}organization:org_{{ randomObjectID }}_{{ $j }}
+    subject: {{ $.Prefix }}platform:plat_{{ randomObjectID }}_{{ $j }}
     relation: platform
   - op: TOUCH
-    resource: {{ $.Prefix }}tenant:ps_{{ $j }}
-    subject: {{ $.Prefix }}organization:org_{{ $j }}
+    resource: {{ $.Prefix }}tenant:ps_{{ randomObjectID }}_{{ $j }}
+    subject: {{ $.Prefix }}organization:org_{{ randomObjectID }}_{{ $j }}
     relation: organization
   - op: TOUCH
-    resource: {{ $.Prefix }}tenant:ps_{{ $j }}
-    subject: {{ $.Prefix }}client:client_{{ $j }}#token
+    resource: {{ $.Prefix }}tenant:ps_{{ randomObjectID }}_{{ $j }}
+    subject: {{ $.Prefix }}client:client_{{ randomObjectID }}_{{ $j }}#token
     relation: writer
 {{- range $i := enumerate 10 }}
   - op: TOUCH
-    resource: {{ $.Prefix }}client:client_{{ $j }}
-    subject: {{ $.Prefix }}token:t_{{ $j }}{{ $i }}
+    resource: {{ $.Prefix }}client:client_{{ randomObjectID }}_{{ $j }}
+    subject: {{ $.Prefix }}token:t_{{ randomObjectID }}_{{ $j }}_{{ $i }}
     relation: token
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# Add configurable step interval; randomize `some-data.yaml` identifiers

## Summary
Adds a `--step-interval` flag to the `run` command so the time between worker steps is configurable instead of hardcoded at one second, and updates `scripts/some-data.yaml` to generate its identifiers from `randomObjectID` so repeated runs produce distinct objects.

## Changes

**`--step-interval` flag for `run`**
- Each worker previously ticked on a hardcoded `1 * time.Second` ticker. That interval is now driven by a new `--step-interval` duration flag (default `1s`).
- Threaded through `WorkerOptions.StepInterval`; `RunWorker` falls back to `1s` if a non-positive value is passed (avoids a `time.NewTicker` panic).
- The worker-start stagger now spreads across one `step-interval` (`stepInterval / qps`) instead of a fixed second, keeping ticks evenly distributed.
- **Default behavior is unchanged.** With the default `1s`, effective throughput stays `qps`; lowering it drives more steps per worker, so total throughput is `qps / step-interval`.

**Randomized identifiers in `some-data.yaml`**
- Resource/subject ids now use `randomObjectID` combined with the loop indices (e.g. `org_{{ randomObjectID }}_{{ $j }}`).
- `randomObjectID` returns one value per render, so it serves as a per-run namespace while the loop indices keep the 100 orgs and their tokens distinct within a single run. Cross-references (e.g. the org written vs. the org referenced) stay consistent because they share the same random value and index.
- Combined with `run --rerender`, each pass through the script re-renders and yields a fresh, distinct set of object ids.
