### PR TITLE
Run worker steps synchronously to avoid overlap

### DIFF
--- a/internal/thumperrunner/thumper.go
+++ b/internal/thumperrunner/thumper.go
@@ -61,7 +61,18 @@ func RunWorker(options WorkerOptions) {
 			return
 		case <-ticker.C:
 			chosen := chooser.Pick().(*ExecutableContext)
-			go chosen.StepForward(options.Index, options.StepTimeout)
+			// Execute the step synchronously: a worker walks its script's steps
+			// one at a time. Launching this in a goroutine let a slow step's
+			// successor start before numExecuted was advanced (it is incremented
+			// only after the RPC returns), so overlapping goroutines re-ran the
+			// SAME step with identical template values — duplicate concurrent
+			// writes of the same relationship, which CockroachDB rejects with
+			// WriteTooOldError (SQLSTATE 40001). It also raced on the shared
+			// numExecuted/zedToken/script fields. Concurrency is provided by
+			// running multiple workers (--qps), not by overlapping a worker with
+			// itself. If a step outlasts the interval, time.Ticker drops the
+			// missed ticks, which is honest backpressure for a load test.
+			chosen.StepForward(options.Index, options.StepTimeout)
 		}
 	}
 }


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

Execute StepForward inline instead of in a per-tick goroutine. The fire-and- forget goroutine let a slow step's successor start before numExecuted was advanced (incremented only after the RPC returns), so overlapping goroutines re-ran the same step with identical template values -- duplicate concurrent writes of the same relationship, which CockroachDB rejects with WriteTooOldError (40001) -- and raced on the shared numExecuted/zedToken/script fields. It also let goroutines pile up unboundedly at small step intervals, driving memory growth. Concurrency now comes from running multiple workers (--qps); if a step outlasts the interval, the ticker drops missed ticks as honest backpressure.

<!--
Why do we need this PR? Any implementation details worth mentioning here?
-->

## Testing

<!--
How did you test this and how can reviewers test this?
-->

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->